### PR TITLE
sparky-web datetime respects TZ

### DIFF
--- a/bin/sparky-web.pl6
+++ b/bin/sparky-web.pl6
@@ -13,7 +13,8 @@ get '/' => sub {
   my $dbh = get-dbh();
 
   my $sth = $dbh.prepare(q:to/STATEMENT/);
-      SELECT * FROM builds order by dt desc
+  SELECT id, project, state, datetime(dt, 'localtime') AS dt FROM builds order by dt desc;
+  #SELECT * FROM builds order by dt desc
   STATEMENT
 
   $sth.execute();


### PR DESCRIPTION
Здравствуйте. Очень маленькое изменение, которое меняет время выполнения сценария в sparky-web. Раньше использовалось то, что было в дб, т.е UTC. Сейчас должно показываться то, что на самом деле сейчас на часах. 
В докере TZ смотрит в UTC. Вот сценарий, которым можно поменять его.

```
package-install ( 'tzdata' );

file '/etc/localtime', %(
  source => '/usr/share/zoneinfo/Europe/Moscow'
);

```