### PR TITLE
Unexpected named argument :no-append-array passed

### DIFF
--- a/bin/sparky-runner.raku
+++ b/bin/sparky-runner.raku
@@ -111,7 +111,7 @@ sub MAIN (
 
   my $sparrowdo-run = "sparrowdo --prefix=$project";
 
-  my %sparrowdo-config = merge-hash (%config<sparrowdo> || Hash.new), (%trigger<sparrowdo>|| Hash.new), :no-append-array;
+  my %sparrowdo-config = merge-hash (%config<sparrowdo> || Hash.new), (%trigger<sparrowdo>|| Hash.new);
 
   say "merged sparrowdo configuration: {Dump(%sparrowdo-config)}";
 


### PR DESCRIPTION
I think that Hash::Merge has been updated very recently and therefore breaks this line (at least I get some problems with it that required to do this fix :D).

Probably the fix is not to remove the named argument but to use ":positional-append" ?

