### PR TITLE
Full width

### DIFF
--- a/views/builds.tt
+++ b/views/builds.tt
@@ -10,7 +10,7 @@
 
     <nav class="panel is-primary">
       <p class="panel-heading">Recent builds</p>
-      <table class="table panel-block">
+      <table class="table is-fullwidth">
         <tr>
           <td>Project</td>
           <td>ID</td>

--- a/views/project.tt
+++ b/views/project.tt
@@ -31,10 +31,11 @@
         <a class="button is-small" onclick="run()" >Run now</a>
       </div>
       % }
-      <div class="panel-block">
+      <div class="is-fullwidth">
         %= "<pre><strong>Configuration</strong>:\n\n" ~ ( $err || $project-conf-str ) ~ "</pre>"
       </div>
-      <div class="panel-block">
+      <div class="panel-block"></div>
+      <div class="is-fullwidth">
         % use HTML::Escape; my $text = escape-html(slurp $path)
         %= "<pre><strong>Scenario</strong>:\n\n" ~ $text ~ "</pre>"
       </div>

--- a/views/projects.tt
+++ b/views/projects.tt
@@ -19,7 +19,7 @@ function run( project ){
     %= $navbar
     <nav class="panel is-primary">
       <p class="panel-heading">Projects</p>
-      <table class="table panel-block">
+      <table class="table is-fullwidth">
         <tr>
           <td>Project</td>
           <td>Last Build</td>

--- a/views/queue.tt
+++ b/views/queue.tt
@@ -10,7 +10,7 @@
 
     <nav class="panel is-primary">
       <p class="panel-heading">Builds queue</p>
-      <table class="table panel-block">
+      <table class="table is-fullwidth">
         <tr>
           <td>Project</td>
           <td>Build Dsc</td>


### PR DESCRIPTION
I don't know why, but locally I have this : 

![Screenshot from 2020-12-30 16-09-18](https://user-images.githubusercontent.com/580360/103361594-896d9f00-4ab9-11eb-83bf-bd7a8ce6f571.png)

(it's not the case on the [rakudist sparky](https://rakudist.raku.org/sparky/))

After this change : 

![Screenshot from 2020-12-30 16-09-46](https://user-images.githubusercontent.com/580360/103361892-9d190580-4ab9-11eb-937b-44eb2ab312a6.png)

